### PR TITLE
Added missing cordova-plugin-inappbrowser.

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -35,4 +35,5 @@
   <plugin name="cordova-plugin-splashscreen" spec="~3.2.2" />
   <plugin name="ionic-plugin-keyboard" spec="~2.2.1" />
   <plugin name="cordova-plugin-device" spec="~1.1.3" />
+  <plugin name="cordova-plugin-inappbrowser" spec="~1.5.0" />
 </widget>


### PR DESCRIPTION
For some reason this didn't get added to the config.xml when using the CLI. I think this is needed for proper `ionic prepare android`?